### PR TITLE
refactor: codebase audit cleanup, verbose flag, and windows tldr support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,8 +126,6 @@ dependencies = [
  "indicatif 0.18.4",
  "reqwest",
  "rusqlite",
- "serde",
- "serde_json",
  "sqlite-vec",
  "zerocopy",
  "zip",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ fastembed = "4.8.0"
 dirs = "5.0.1"
 reqwest = { version = "0.12", features = ["blocking"] }
 rusqlite = { version = "0.35.0", features = ["bundled"] }
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
 sqlite-vec = "0.1.6"
 zerocopy = "0.8.25"
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Requires [Rust](https://rust-lang.org/tools/install/):
 cargo install --git https://github.com/0bmario/askman
 ```
 
-On first run, `askman` downloads a small embedding model and command database.
+On first run, `askman` downloads a small embedding model and commands database.
 
 ## Usage
 
@@ -66,8 +66,7 @@ Kudos to the [tldr-pages](https://github.com/tldr-pages/tldr) project. The used 
 
 ## Rebuilding the Database
 
-Want to refresh the database with the absolute latest commands?
 ```bash
 cargo run --bin import_tldr --features="dev"
 ```
-This automatically fetches the newest data from the tldr repository, extracts it, and generates a fresh database for your system.
+This automatically fetches the newest data from the tldr repository, extracts it, and generates a fresh commands database.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,10 @@ pub struct Args {
     #[arg(long, short = 'c')]
     pub clean: bool,
 
+    /// Print internal matching scores (adjusted ranking distance, raw cosine distance, and applied heuristics)
+    #[arg(long, short = 'v')]
+    pub verbose: bool,
+
     /// Force search for Linux commands
     #[arg(long, conflicts_with_all = ["osx", "windows"])]
     pub linux: bool,

--- a/src/db.rs
+++ b/src/db.rs
@@ -36,6 +36,10 @@ pub fn get_db_path(app_dir: &Path) -> Result<PathBuf> {
 
     let global_db_path = app_dir.join("commands.db");
 
+    if global_db_path.exists() {
+        ensure_valid_schema(&global_db_path)?;
+    }
+
     if !global_db_path.exists() {
         println!("Downloading initial commands database (this only happens once)...");
 
@@ -93,4 +97,36 @@ pub fn get_db_path(app_dir: &Path) -> Result<PathBuf> {
 
 pub fn get_connection(db_path: &Path) -> Result<Connection> {
     Ok(Connection::open(db_path)?)
+}
+
+/// Checks if the database has the required schema (must have the `os` metadata column).
+/// If it's an old v1 schema (missing `os`), it actively removes it so it can be rebuilt.
+pub fn ensure_valid_schema(db_path: &Path) -> Result<()> {
+    if !db_path.exists() {
+        return Ok(());
+    }
+
+    let has_os_column = {
+        let conn = get_connection(db_path)?;
+        let mut stmt = conn.prepare("PRAGMA table_info(pages_vec)")?;
+        let mut rows = stmt.query([])?;
+        let mut found = false;
+        while let Some(row) = rows.next()? {
+            let name: String = row.get(1)?;
+            if name == "os" {
+                found = true;
+                break;
+            }
+        }
+        found
+    };
+
+    if !has_os_column {
+        println!(
+            "Detected legacy database schema (v1, missing OS flags). Removing to allow upgrade..."
+        );
+        std::fs::remove_file(db_path)?;
+    }
+
+    Ok(())
 }

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -9,8 +9,8 @@ pub fn init_model(app_dir: &Path) -> Result<TextEmbedding> {
         .with_cache_dir(cache_dir.clone());
     TextEmbedding::try_new(embed_options).with_context(|| {
         format!(
-            "failed to initialize embedding model AllMiniLML6V2 with cache_dir {:?}",
-            cache_dir
+            "failed to initialize embedding model AllMiniLML6V2 with cache_dir {}",
+            cache_dir.display()
         )
     })
 }

--- a/src/import_tldr.rs
+++ b/src/import_tldr.rs
@@ -8,8 +8,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use zerocopy::IntoBytes;
 
-#[path = "db.rs"]
-mod db;
+use askman::db;
 
 /// Downloads and extracts the tldr-pages repo zip into a temp directory.
 /// Returns the path to the extracted `pages/` folder (e.g. /tmp/askman_tldr/tldr-main/pages).
@@ -81,7 +80,7 @@ fn main() -> Result<()> {
     )?;
 
     let mut count = 0;
-    for os_type in ["common", "linux", "osx"] {
+    for os_type in ["common", "linux", "osx", "windows"] {
         let dir = pages_dir.join(os_type);
         if dir.exists() {
             println!("Processing directory: {}", os_type);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod cli;
+pub mod db;
+pub mod embed;
+pub mod format;
+pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,6 @@
-mod cli;
-mod db;
-mod embed;
-mod format;
-mod search;
-
 use anyhow::Result;
+
+use askman::{cli, db, embed, format, search};
 use clap::Parser;
 use colored::*;
 use rusqlite::ffi::sqlite3_auto_extension;
@@ -47,7 +43,7 @@ fn main() -> Result<()> {
     // CLI flags override auto-detection; default maps to host OS
     let target_os = search::get_target_os(args.linux, args.osx, args.windows);
 
-    try_semantic_search(&conn, &query, &app_dir, target_os)
+    try_semantic_search(&conn, &query, &app_dir, target_os, args.verbose)
 }
 
 /// Embeds the query, runs KNN against sqlite-vec, ranks results, and prints output.
@@ -55,20 +51,20 @@ fn try_semantic_search(
     conn: &rusqlite::Connection,
     query: &str,
     app_dir: &std::path::Path,
-    target_os: &str,
+    target_os: search::TargetOs,
+    verbose: bool,
 ) -> Result<()> {
     let embedder = embed::init_model(app_dir)?;
     let q_vec = embed::embed_query(&embedder, query)?;
-
     let sorted = search::perform_search(conn, &q_vec, target_os)?;
 
-    for (i, (cmd, (desc, examples, _))) in sorted.iter().enumerate().take(3) {
-        let mut show_count = if i == 0 { examples.len() } else { 0 };
+    for (i, (cmd, data)) in sorted.iter().enumerate().take(3) {
+        let mut show_count = if i == 0 { data.examples.len() } else { 0 };
 
         // only show more than 1 command if it's exceptionally close in meaning to the top result
         if i > 0 {
-            let top_score = sorted[0].1.2;
-            let current_score = sorted[i].1.2;
+            let top_score = sorted[0].1.adjusted_score;
+            let current_score = sorted[i].1.adjusted_score;
             // if it's very close, we can show one example for it
             if current_score - top_score < 0.05 {
                 show_count = 1;
@@ -78,18 +74,33 @@ fn try_semantic_search(
         }
 
         println!("{}", cmd.bold().green());
+        if verbose {
+            let rules = if data.heuristics.is_empty() {
+                "none".to_string()
+            } else {
+                data.heuristics.join(", ")
+            };
+            println!(
+                "{}",
+                format!(
+                    "(Distance: {:.4} | Raw: {:.4} | Rules: {})",
+                    data.adjusted_score, data.raw_distance, rules
+                )
+                .bright_black()
+            );
+        }
 
         // Clean up description (strip "More information" links)
-        let clean_desc = if let Some(idx) = desc.find(" More information:") {
-            &desc[..idx]
+        let clean_desc = if let Some(idx) = data.description.find(" More information:") {
+            &data.description[..idx]
         } else {
-            desc
+            &data.description
         };
         println!("{}", clean_desc);
 
-        if show_count > 0 && !examples.is_empty() {
+        if show_count > 0 && !data.examples.is_empty() {
             println!("\n{}", "Examples:".underline());
-            for (ex_desc, ex_cmd) in examples.iter().take(show_count) {
+            for (ex_desc, ex_cmd) in data.examples.iter().take(show_count) {
                 println!("  {}", ex_desc);
                 println!("   {}", format::highlight_command(ex_cmd));
                 println!();

--- a/src/search.rs
+++ b/src/search.rs
@@ -4,8 +4,32 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use zerocopy::IntoBytes;
 
-// (description, [(example_desc, example_cmd)], adjusted_score)
-pub type CmdData = (String, Vec<(String, String)>, f64);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetOs {
+    Linux,
+    Osx,
+    Windows,
+}
+
+impl TargetOs {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Linux => "linux",
+            Self::Osx => "osx",
+            Self::Windows => "windows",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CmdData {
+    pub description: String,
+    pub examples: Vec<(String, String)>,
+    pub adjusted_score: f64,
+    pub raw_distance: f64,
+    pub heuristics: Vec<String>,
+}
+
 pub type CmdMap = HashMap<String, CmdData>;
 
 /// Domains that indicate an "official" man page source
@@ -25,31 +49,30 @@ const OFFICIAL_SITES: &[&str] = &[
 /// See: https://alexgarcia.xyz/sqlite-vec/api-reference.html#vec_distance_cosine
 const MAX_DISTANCE: f64 = 1.10;
 
-pub fn get_target_os(linux: bool, osx: bool, windows: bool) -> &'static str {
-    if linux {
-        "linux"
-    } else if osx {
-        "osx"
-    } else if windows {
-        "windows"
-    } else {
-        match std::env::consts::OS {
-            "macos" => "osx",
-            "windows" => "windows",
-            _ => "linux",
-        }
+pub fn get_target_os(linux: bool, osx: bool, windows: bool) -> TargetOs {
+    match (linux, osx, windows) {
+        (true, _, _) => TargetOs::Linux,
+        (_, true, _) => TargetOs::Osx,
+        (_, _, true) => TargetOs::Windows,
+        _ => match std::env::consts::OS {
+            "macos" => TargetOs::Osx,
+            "windows" => TargetOs::Windows,
+            _ => TargetOs::Linux,
+        },
     }
 }
 
 /// Pure scoring function: adjusts raw distance based on command name and description heuristics.
 /// Returns `None` if the result should be filtered out (score above threshold).
-pub fn adjust_score(cmd: &str, desc: &str, raw_distance: f64) -> Option<f64> {
+pub fn adjust_score(cmd: &str, desc: &str, raw_distance: f64) -> Option<(f64, Vec<String>)> {
     if raw_distance > MAX_DISTANCE {
         return None;
     }
 
+    let mut applied_heuristics = Vec::new();
     let is_official = OFFICIAL_SITES.iter().any(|&site| desc.contains(site));
     let mut score = if is_official {
+        applied_heuristics.push("official_site (0.8x)".to_string());
         raw_distance * 0.8
     } else {
         raw_distance
@@ -57,6 +80,7 @@ pub fn adjust_score(cmd: &str, desc: &str, raw_distance: f64) -> Option<f64> {
 
     // Heuristic to prefer basic unix commands over niche variants
     if cmd == "grep" || (cmd.len() <= 3 && !cmd.starts_with('q') && !cmd.starts_with('z')) {
+        applied_heuristics.push("core_command (0.67x)".to_string());
         score *= 0.67; // Boost core commands like 'mv', 'cp', 'rm', 'grep'
     } else if cmd.contains('-')
         || cmd.starts_with('q')
@@ -64,16 +88,17 @@ pub fn adjust_score(cmd: &str, desc: &str, raw_distance: f64) -> Option<f64> {
         || (cmd.ends_with("grep") && cmd != "grep")
         || cmd.ends_with("all")
     {
+        applied_heuristics.push("niche_variant (1.33x)".to_string());
         score *= 1.33; // Penalize niche variants
     }
 
-    Some(score)
+    Some((score, applied_heuristics))
 }
 
 pub fn perform_search(
     conn: &Connection,
     q_vec: &[f32],
-    target_os: &str,
+    target_os: TargetOs,
 ) -> anyhow::Result<Vec<(String, CmdData)>> {
     let q_blob = q_vec.as_bytes();
 
@@ -85,7 +110,7 @@ pub fn perform_search(
          LIMIT 7;",
     )?;
 
-    let results = stmt.query_map(params![q_blob, target_os], |row| {
+    let results = stmt.query_map(params![q_blob, target_os.as_str()], |row| {
         Ok((
             row.get::<_, String>(0)?,
             row.get::<_, String>(1)?,
@@ -98,27 +123,35 @@ pub fn perform_search(
     let mut command_map: CmdMap = HashMap::new();
 
     for result in results {
-        let (cmd, desc, ex_desc, ex_cmd, score) = result?;
+        let (cmd, desc, ex_desc, ex_cmd, raw_distance) = result?;
 
-        let adjusted_score = match adjust_score(&cmd, &desc, score) {
+        let (adjusted_score, heuristics) = match adjust_score(&cmd, &desc, raw_distance) {
             Some(s) => s,
-            None => continue,
+            None => {
+                continue;
+            }
         };
 
         match command_map.entry(cmd.clone()) {
             Entry::Vacant(e) => {
-                e.insert((desc, vec![(ex_desc, ex_cmd)], adjusted_score));
+                e.insert(CmdData {
+                    description: desc,
+                    examples: vec![(ex_desc, ex_cmd)],
+                    adjusted_score,
+                    raw_distance,
+                    heuristics,
+                });
             }
             Entry::Occupied(mut o) => {
-                o.get_mut().1.push((ex_desc, ex_cmd));
+                o.get_mut().examples.push((ex_desc, ex_cmd));
             }
         }
     }
 
     let mut sorted: Vec<(String, CmdData)> = command_map.into_iter().collect();
     sorted.sort_by(|a, b| {
-        a.1.2
-            .partial_cmp(&b.1.2)
+        a.1.adjusted_score
+            .partial_cmp(&b.1.adjusted_score)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
@@ -133,22 +166,22 @@ mod tests {
 
     #[test]
     fn test_explicit_linux_flag() {
-        assert_eq!(get_target_os(true, false, false), "linux");
+        assert_eq!(get_target_os(true, false, false), TargetOs::Linux);
     }
 
     #[test]
     fn test_explicit_osx_flag() {
-        assert_eq!(get_target_os(false, true, false), "osx");
+        assert_eq!(get_target_os(false, true, false), TargetOs::Osx);
     }
 
     #[test]
     fn test_explicit_windows_flag() {
-        assert_eq!(get_target_os(false, false, true), "windows");
+        assert_eq!(get_target_os(false, false, true), TargetOs::Windows);
     }
 
     #[test]
     fn test_linux_takes_priority_over_osx() {
-        assert_eq!(get_target_os(true, true, false), "linux");
+        assert_eq!(get_target_os(true, true, false), TargetOs::Linux);
     }
 
     // --- adjust_score ---
@@ -166,41 +199,42 @@ mod tests {
 
     #[test]
     fn test_core_command_boosted() {
-        let ls_score = adjust_score("ls", "list files", 0.5).unwrap();
+        let (ls_score, _) = adjust_score("ls", "list files", 0.5).unwrap();
         // 'ls' is <= 3 chars, not q/z prefix -> boosted by 0.67x (lower distance)
         assert!((ls_score - 0.335).abs() < 0.001);
     }
 
     #[test]
     fn test_grep_boosted() {
-        let grep_score = adjust_score("grep", "search patterns", 0.5).unwrap();
+        let (grep_score, _) = adjust_score("grep", "search patterns", 0.5).unwrap();
         assert!((grep_score - 0.335).abs() < 0.001);
     }
 
     #[test]
     fn test_niche_variant_penalized() {
-        let zgrep_score = adjust_score("zgrep", "search compressed", 0.5).unwrap();
+        let (zgrep_score, _) = adjust_score("zgrep", "search compressed", 0.5).unwrap();
         // starts with 'z' AND ends with "grep" -> penalized by 1.33x
         assert!((zgrep_score - 0.665).abs() < 0.001);
     }
 
     #[test]
     fn test_hyphenated_command_penalized() {
-        let score = adjust_score("docker-cp", "copy files", 0.5).unwrap();
+        let (score, _) = adjust_score("docker-cp", "copy files", 0.5).unwrap();
         assert!((score - 0.665).abs() < 0.001);
     }
 
     #[test]
     fn test_official_site_boosts_score() {
-        let plain = adjust_score("find", "find files", 0.5).unwrap();
-        let official = adjust_score("find", "find files. More information: gnu.org", 0.5).unwrap();
+        let (plain, _) = adjust_score("find", "find files", 0.5).unwrap();
+        let (official, _) =
+            adjust_score("find", "find files. More information: gnu.org", 0.5).unwrap();
         assert!(official < plain); // lower distance is better
     }
 
     #[test]
     fn test_normal_command_no_modifier() {
         // 'curl' is 4 chars, no special prefix/suffix -> no boost or penalty
-        let score = adjust_score("curl", "transfer data", 0.5).unwrap();
+        let (score, _) = adjust_score("curl", "transfer data", 0.5).unwrap();
         assert!((score - 0.5).abs() < 0.001);
     }
 }


### PR DESCRIPTION
- Remove unused, refactors
- Add  /  flag to expose sqlite-vec cosine distance and applied scoring heuristics
- Restore  legacy schema drop logic in  to allow smooth upgrades to
- Include Windows pages when building the TLDR database


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added verbose flag (-v/--verbose) for detailed search diagnostics
  * Added processing support for Windows-specific command pages

* **Improvements**
  * Enhanced search scoring with heuristic labels and richer result metadata
  * Automatic database schema validation and upgrade handling for legacy databases
  * More informative error messages during model initialization

* **Documentation**
  * Clarified on-first-run messaging about fetching and generating the commands database
<!-- end of auto-generated comment: release notes by coderabbit.ai -->